### PR TITLE
mod git clone URL git to https

### DIFF
--- a/docs/denso_cobotta_ros/_sources/getting_started.txt
+++ b/docs/denso_cobotta_ros/_sources/getting_started.txt
@@ -44,7 +44,7 @@ Build
 
       $ mkdir -p ~/catkin_ws/src
       $ cd ~/catkin_ws/src
-      $ git clone git@github.com:DENSORobot/denso_cobotta_ros.git
+      $ git clone https://github.com/DENSORobot/denso_cobotta_ros.git
 
 #. Build
 


### PR DESCRIPTION
"git@github.dom:..." URL needs other settings for github.
I think it's better to use "https://github.com/..." URL for the Getting Started domument.