### PR TITLE
Dpam notes

### DIFF
--- a/docs/denso_cobotta_ros/command_reference/rosservice.html
+++ b/docs/denso_cobotta_ros/command_reference/rosservice.html
@@ -281,6 +281,8 @@
 </tr>
 </tbody>
 </table>
+<sub>Here is a link for creating different colors using an RGB table code chart: <a href="https://www.rapidtables.com/web/color/RGB_Color.html">RGB Color Codes Chart</a>.</sub>
+<p></p>
 <div class="admonition attention">
 <p class="first admonition-title">Attention</p>
 <p class="last">If you set the blink_rate small number, LED blinks quickly.

--- a/docs/denso_cobotta_ros/command_reference/rostopic.html
+++ b/docs/denso_cobotta_ros/command_reference/rostopic.html
@@ -236,6 +236,8 @@
 </li>
 </ol>
 </div>
+<sub>Bit number 0 (CPU Normal) is a resevered output (pin 45) and cannot be set by the rostopic command.</sub>
+<p></p>
 <div class="section" id="robot-state">
 <h2>Robot state<a class="headerlink" href="#robot-state" title="Permalink to this headline">¶</a></h2>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic echo -c /cobotta/robot_state
@@ -322,6 +324,13 @@ Before 1.2.1, <code class="docutils literal notranslate"><span class="pre">targe
 </tr>
 </tbody>
 </table>
+<div class="admonition note">
+  <p class="first admonition-title">Note</p>
+  <p class="last">In order to use the vacuum, the electric gripper must be swapped for the vacuum gripper by a certified 
+    DENSO employee. To launch the MOVEIT software to work with the vacuum, 
+    enter the following into the terminal: <code class="docutils literal notranslate"><span class="pre">roslaunch</span> <span class="pre">denso_cobotta_bringup</span> <span class="pre">denso_cobotta_bringup.launch gripper_type:=vacuum</span></code></p>
+  </div>
+</li>
 <ol class="arabic">
 <li><p class="first">Suction</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic pub /cobotta/vacuum_move/goal \

--- a/docs/denso_cobotta_ros/command_reference/rostopic.html
+++ b/docs/denso_cobotta_ros/command_reference/rostopic.html
@@ -236,8 +236,6 @@
 </li>
 </ol>
 </div>
-<sub>Bit number 0 (CPU Normal) is a resevered output (pin 45) and cannot be set by the rostopic command.</sub>
-<p></p>
 <div class="section" id="robot-state">
 <h2>Robot state<a class="headerlink" href="#robot-state" title="Permalink to this headline">¶</a></h2>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic echo -c /cobotta/robot_state
@@ -324,13 +322,6 @@ Before 1.2.1, <code class="docutils literal notranslate"><span class="pre">targe
 </tr>
 </tbody>
 </table>
-<div class="admonition note">
-  <p class="first admonition-title">Note</p>
-  <p class="last">In order to use the vacuum, the electric gripper must be swapped for the vacuum gripper by a certified 
-    DENSO employee. To launch the MOVEIT software to work with the vacuum, 
-    enter the following into the terminal: <code class="docutils literal notranslate"><span class="pre">roslaunch</span> <span class="pre">denso_cobotta_bringup</span> <span class="pre">denso_cobotta_bringup.launch gripper_type:=vacuum</span></code></p>
-  </div>
-</li>
 <ol class="arabic">
 <li><p class="first">Suction</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic pub /cobotta/vacuum_move/goal \

--- a/docs/denso_cobotta_ros/command_reference/rostopic.html
+++ b/docs/denso_cobotta_ros/command_reference/rostopic.html
@@ -223,6 +223,8 @@
 </tr>
 </tbody>
 </table>
+<sub>Bit number 45 (CPU Normal) is always on.</sub>
+<p></p>
 <ol class="arabic">
 <li><p class="first">Get the Mini IO data</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic echo -c /cobotta/miniIO_input
@@ -322,6 +324,13 @@ Before 1.2.1, <code class="docutils literal notranslate"><span class="pre">targe
 </tr>
 </tbody>
 </table>
+<div class="admonition note">
+  <p class="first admonition-title">Note</p>
+  <p class="last">In order to use the vacuum, the electric gripper must be swapped for the vacuum gripper by a certified 
+    DENSO employee. To launch the MOVEIT software to work with the vacuum, 
+    enter the following into the terminal: <code class="docutils literal notranslate"><span class="pre">roslaunch</span> <span class="pre">denso_cobotta_bringup</span> <span class="pre">denso_cobotta_bringup.launch gripper_type:=vacuum</span></code></p>
+  </div>
+</li>
 <ol class="arabic">
 <li><p class="first">Suction</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic pub /cobotta/vacuum_move/goal \

--- a/docs/denso_cobotta_ros/command_reference/rostopic.html
+++ b/docs/denso_cobotta_ros/command_reference/rostopic.html
@@ -223,8 +223,6 @@
 </tr>
 </tbody>
 </table>
-<sub>Bit number 45 (CPU Normal) is always on.</sub>
-<p></p>
 <ol class="arabic">
 <li><p class="first">Get the Mini IO data</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic echo -c /cobotta/miniIO_input
@@ -324,13 +322,6 @@ Before 1.2.1, <code class="docutils literal notranslate"><span class="pre">targe
 </tr>
 </tbody>
 </table>
-<div class="admonition note">
-  <p class="first admonition-title">Note</p>
-  <p class="last">In order to use the vacuum, the electric gripper must be swapped for the vacuum gripper by a certified 
-    DENSO employee. To launch the MOVEIT software to work with the vacuum, 
-    enter the following into the terminal: <code class="docutils literal notranslate"><span class="pre">roslaunch</span> <span class="pre">denso_cobotta_bringup</span> <span class="pre">denso_cobotta_bringup.launch gripper_type:=vacuum</span></code></p>
-  </div>
-</li>
 <ol class="arabic">
 <li><p class="first">Suction</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic pub /cobotta/vacuum_move/goal \

--- a/docs/denso_cobotta_ros/command_reference/rostopic.html
+++ b/docs/denso_cobotta_ros/command_reference/rostopic.html
@@ -236,6 +236,8 @@
 </li>
 </ol>
 </div>
+<sub>Bit number 0 (CPU Normal, pin 45) is a resevered output and cannot be set by the rostopic command.</sub>
+<p></p>
 <div class="section" id="robot-state">
 <h2>Robot state<a class="headerlink" href="#robot-state" title="Permalink to this headline">¶</a></h2>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic echo -c /cobotta/robot_state
@@ -322,6 +324,14 @@ Before 1.2.1, <code class="docutils literal notranslate"><span class="pre">targe
 </tr>
 </tbody>
 </table>
+<div class="admonition note">
+  <p class="first admonition-title">Note</p>
+  <p class="last">In order to use the vacuum, the electric gripper must be swapped for the vacuum gripper by a certified 
+    DENSO employee. To launch the MOVEIT software to work with the vacuum, 
+    enter the following into the terminal: <code class="docutils literal notranslate"><span class="pre">roslaunch</span> <span class="pre">denso_cobotta_bringup</span> <span class="pre">denso_cobotta_bringup.launch gripper_type:=vacuum</span></code></p>
+  </div>
+</li>
+
 <ol class="arabic">
 <li><p class="first">Suction</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ rostopic pub /cobotta/vacuum_move/goal \


### PR DESCRIPTION
I added a note to the ROSTOPIC Vacuum gripper section

I added under the Mini-IO section in ROSTOPIC that bit 0 is always on and cannot be chnaged.

I added a website for the LED, under the ROSSERVICE commands, that directs clients to an RGB table code chart link